### PR TITLE
feat(types): Add TypeScript support for slay-terminus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,6 @@ build/Release
 node_modules/
 jspm_packages/
 
-# TypeScript v1 declaration files
-typings/
-
 # Optional npm cache directory
 .npm
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4122,6 +4122,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "description": "Slay preboot providing shutdown and Kubernetes readiness / liveness checks with terminus.",
   "main": "lib/index.js",
   "module": "lib/index.js",
+  "types": "typings/index.d.ts",
   "scripts": {
     "coverage": "nyc mocha --recursive lib",
     "lint": "eslint-godaddy --max-warnings 0 --ignore-pattern /coverage/ ./",
     "release": "standard-version",
-    "test": "mocha --recursive lib"
+    "test": "npm run test:mocha && npm run test:types",
+    "test:mocha": "mocha --recursive lib",
+    "test:types": "tsc --esModuleInterop --lib es2015,dom --noEmit ./typings/*.ts"
   },
   "keywords": [
     "slay",
@@ -34,7 +37,8 @@
     "mocha": "^8.1.1",
     "nyc": "^14.1.1",
     "sinon": "^7.4.1",
-    "standard-version": "^9.0.0"
+    "standard-version": "^9.0.0",
+    "typescript": "^4.0.3"
   },
   "nyc": {
     "check-coverage": true,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,9 @@
+declare module 'slay-terminus' {
+  import { TerminusOptions } from '@godaddy/terminus';
+
+  type SlayTerminus = (app: any, opts: Object, done: () => any) => void;
+
+  function createSlayTerminus(TerminusOptions: TerminusOptions): SlayTerminus;
+
+  export = createSlayTerminus;
+}

--- a/typings/index.test.ts
+++ b/typings/index.test.ts
@@ -1,0 +1,22 @@
+import { TerminusOptions } from '@godaddy/terminus';
+import _createSlayTerminus = require('slay-terminus');
+import createSlayTerminus from 'slay-terminus';
+
+const terminusOptions: TerminusOptions = {
+  healthChecks: {
+    '/healthcheck': () => Promise.resolve()
+  },
+  logger: console.log
+};
+
+const fakeApp = {};
+const fakeOpts = {};
+const fakeDone = () => {};
+
+const _slayTerminus = _createSlayTerminus({ ...terminusOptions, signal: 'test' });
+
+_slayTerminus(fakeApp, fakeOpts, fakeDone);
+
+const slayTerminus = createSlayTerminus({ ...terminusOptions, signal: 'test' });
+
+slayTerminus(fakeApp, fakeOpts, fakeDone);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Hello 👋, nice project!
I've contributed to `terminus` type definition file recently and wanted to add typescript support for this project as well. In hopes to be able to use both modules in typescript projects.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` and `npm run lint` pass
- [x] tests are included
- [x] PR title follows [conventional commits guidelines](https://www.npmjs.com/package/@commitlint/config-conventional)
